### PR TITLE
Json export

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Tamás Cserteg <csertegt@gmail.com>"]
 version = "0.2.0"
 
 [deps]
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
@@ -12,10 +13,11 @@ RegionTrees = "dee08c22-ab7f-5625-9660-a9af2021b33f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-julia = "^1"
+Parameters = "0.12"
 RegionTrees = "^0.3"
 StaticArrays = "0.11, 0.12"
-Parameters = "0.12"
+julia = "^1"
+JSON = "0.20, 0.21"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,8 @@ makedocs(sitename="RANSAC.jl",
         pages=["Home" => "index.md",
                 "Example" => "example.md",
                 "Efficient RANSAC" => "ransac.md",
-                "API" => "api.md"])
+                "API" => "api.md",
+                "New primitive"=>"newprimitive.md"])
 
 
 deploydocs(repo="github.com/cserteGT3/RANSAC.jl.git")

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -86,3 +86,105 @@ The `ransac()` function does the iteration.
 ```@docs
 ransac
 ```
+
+## Exporting the results
+
+With the help of [JSON.jl](https://github.com/JuliaIO/JSON.jl), the resulted shapes can be easily saved to JSON files.
+For this purpose, the `exportJSON()` function can be used. Note that `io` must be specified, the "default" fallback to `stdout` is not implemented.
+```@docs
+exportJSON
+```
+
+A few examples:
+```julia
+julia> using RANSAC, StaticArrays
+
+julia> s1 = FittedPlane(SVector(0,0,1.), SVector(12.5, 7, 24))
+FittedPlane{SArray{Tuple{3},Float64,1,3}}
+normal: [12.5, 7.0, 24.0], point: [0.0, 0.0, 1.0]
+
+julia> exportJSON(stdout, s1)
+{"point":[0.0,0.0,1.0],"normal":[12.5,7.0,24.0],"type":"plane"}
+
+julia> exportJSON(stdout, s1, 2)
+{
+  "point": [
+    0.0,
+    0.0,
+    1.0
+  ],
+  "normal": [
+    12.5,
+    7.0,
+    24.0
+  ],
+  "type": "plane"
+}
+```
+It is advised to export shapes in an array for easier processing (though I'm not a JSON expert):
+```julia
+julia> exportJSON(stdout, [s1])
+{"primitives":[{"point":[0.0,0.0,1.0],"normal":[12.5,7.0,24.0],"type":"plane"}]}
+
+julia> exportJSON(stdout, [s1], 2)
+{
+  "primitives": [
+    {
+      "point": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "normal": [
+        12.5,
+        7.0,
+        24.0
+      ],
+      "type": "plane"
+    }
+  ]
+}
+```
+
+Works of course for different primitives:
+```julia
+julia> s2 = FittedSphere(SVector(1.2, 3., 5.), 1.5, true)
+FittedSphere{SArray{Tuple{3},Float64,1,3}, Float64}
+center: [1.2, 3.0, 5.0], R: 1.5, outwards
+
+julia> exportJSON(stdout, [s1, s2], 2)
+{
+  "primitives": [
+    {
+      "point": [
+        0.0,
+        0.0,
+        1.0
+      ],
+      "normal": [
+        12.5,
+        7.0,
+        24.0
+      ],
+      "type": "plane"
+    },
+    {
+      "outwards": true,
+      "radius": 1.5,
+      "center": [
+        1.2,
+        3.0,
+        5.0
+      ],
+      "type": "sphere"
+    }
+  ]
+}
+```
+
+As can be seen above, in these cases an array of `"primitives"` is printed.
+Under the hood, the `toDict()` function does the job of converting the primitives to `Dict`s.
+```@docs
+RANSAC.toDict(s::FittedShape)
+RANSAC.toDict(::Vector{T}) where {T<:Union{FittedShape,ShapeCandidate,ScoredShape}}
+```

--- a/docs/src/newprimitive.md
+++ b/docs/src/newprimitive.md
@@ -1,0 +1,12 @@
+# Introducing a new primitive shape
+
+!!! danger "WIP!"
+    This is currently work in progress, not yet working. This page is primarily a documentation for myself.
+
+A primitive must define the following functions:
+- `strt()`
+- a constructor that acceppts a dictionary with string keys, which keys match the fieldnames.
+
+```@docs
+RANSAC.strt
+```

--- a/docs/src/newprimitive.md
+++ b/docs/src/newprimitive.md
@@ -5,7 +5,7 @@
 
 A primitive must define the following functions:
 - `strt()`
-- a constructor that acceppts a dictionary with string keys, which keys match the fieldnames.
+- (a constructor that accepts a dictionary with string keys, which keys match the fieldnames.)
 
 ```@docs
 RANSAC.strt

--- a/src/RANSAC.jl
+++ b/src/RANSAC.jl
@@ -8,6 +8,7 @@ using StaticArrays: SVector, SMatrix
 using RegionTrees
 #using Images: label_components, component_lengths, component_subscripts
 using Parameters
+import JSON
 
 import RegionTrees: AbstractRefinery, needs_refinement, refine_data
 import Base: show
@@ -92,6 +93,8 @@ export  nosource_debuglogger,
         nosource_Errorlog,
         nosource_metafmt
 
+export  exportJSON
+
 include("utilities.jl")
 include("confidenceintervals.jl")
 include("octree.jl")
@@ -105,5 +108,6 @@ include("sampling.jl")
 include("iterations.jl")
 include("logging.jl")
 include("orientedbox_.jl")
+include("json.jl")
 
 end #module

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -4,6 +4,11 @@ An abstract type that supertypes all the fitted shapes.
 abstract type FittedShape end
 
 """
+Return a string that tells the type (plane, spehere, etc.) of a `FittedShape`.
+"""
+function strt end
+
+"""
     struct ShapeCandidate{S<:FittedShape}
 
 Store a primitive candidate and the octree level, that it is from.

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -101,7 +101,7 @@ function forcefitshapes!(pc, points, normals, parameters, candidates, octree_lev
         else
             error("$s is not recognized as valid shape type.")
         end
-        isshape(fitted) && push!(candidates, ShapeCandidate(fitted, octree_lev))
+        fitted === nothing || push!(candidates, ShapeCandidate(fitted, octree_lev))
     end
     return candidates
 end

--- a/src/json.jl
+++ b/src/json.jl
@@ -1,0 +1,59 @@
+# export/import as/from JSON
+
+"""
+    toDict(s::FittedShape)
+
+Convert `s` to a `Dict{String,Any}`. It's "type" is defined by [`strt`](@ref).
+All fields of the struct is saved to the dict.
+"""
+function toDict(s::FittedShape)
+    d = Dict{String,Any}("type"=>strt(s))
+    for f in fieldnames(typeof(s))
+        sf = String(f)
+        merge!(d, Dict(sf=>getfield(s, f)))
+    end
+    d
+end
+
+toDict(sc::ShapeCandidate) = toDict(sc.shape)
+
+toDict(scs::ScoredShape) = toDict(scs.candidate.shape)
+
+"""
+    toDict(a::Vector{T}) where {T<:Union{FittedShape,ShapeCandidate,ScoredShape}}
+
+Convert a vector of shapes to a `Dict{String,Any}`. The top key is a "primitive", whose value is the array of the shapes.
+See the documentation for examples.
+"""
+function toDict(a::Vector{T}) where {T<:Union{FittedShape,ShapeCandidate,ScoredShape}}
+    ad = toDict.(a)
+    return Dict("primitives"=>ad)
+end
+
+"""
+    printJSON(io::IO, s, indent)
+
+Print a `FittedShape`, `ShapeCandidate`, `ScoredShape` or a vector of them to `io` as a JSON string.
+With `indent` given, it prints a representation with newlines and indents.
+
+# Arguments:
+- `io::IO`: must be specified, use `stdout` for interactive purposes.
+- `s`: a `FittedShape`, `ShapeCandidate`, `ScoredShape` or a vector of one of them.
+- `indent::Int`: indentation level.
+"""
+function exportJSON(io::IO, s, indent)
+    JSON.print(io, toDict(s), indent)
+end
+
+"""
+    printJSON(io::IO, s)
+
+Print a `FittedShape`, `ShapeCandidate`, `ScoredShape` or a vector of them to `io` as a compact JSON string.
+
+# Arguments:
+- `io::IO`: must be specified, use `stdout` for interactive purposes.
+- `s`: a `FittedShape`, `ShapeCandidate`, `ScoredShape` or a vector of one of them.
+"""
+function exportJSON(io::IO, s)
+    JSON.print(io, toDict(s))
+end

--- a/src/shapes/cone.jl
+++ b/src/shapes/cone.jl
@@ -22,9 +22,9 @@ Base.show(io::IO, x::FittedCone) =
     print(io, """cone, ω: $(x.opang)""")
 
 Base.show(io::IO, ::MIME"text/plain", x::FittedCone{A, R}) where {A, R} =
-    print(io, """FittedCone{$A, $R}\ncone, apex: $(x.apex), axis: $(x.axis), ω: $(x.opang), $(x.outwards ? "outwards" : "inwards" )""")
+    print(io, """FittedCone{$A, $R}\napex: $(x.apex), axis: $(x.axis), ω: $(x.opang), $(x.outwards ? "outwards" : "inwards" )""")
 
-strt(x::FittedCone) = "Cone"
+strt(x::FittedCone) = "cone"
 
 function setconeOuterity(fc, b)
     FittedCone(fc.apex, fc.axis, fc.opang, b)

--- a/src/shapes/cylinder.jl
+++ b/src/shapes/cylinder.jl
@@ -19,7 +19,7 @@ Base.show(io::IO, x::FittedCylinder) =
     print(io, """cylinder, R: $(x.radius)""")
 
 Base.show(io::IO, ::MIME"text/plain", x::FittedCylinder{A, R}) where {A, R} =
-    print(io, """FittedCylinder{$A, $R}\ncylinder, center: $(x.center), axis: $(x.axis), R: $(x.radius), $(x.outwards ? "outwards" : "inwards" )""")
+    print(io, """FittedCylinder{$A, $R}\ncenter: $(x.center), axis: $(x.axis), R: $(x.radius), $(x.outwards ? "outwards" : "inwards" )""")
 
 strt(x::FittedCylinder) = "cylinder"
 

--- a/src/shapes/cylinder.jl
+++ b/src/shapes/cylinder.jl
@@ -9,7 +9,6 @@ and its radius.
 Also stored, if the normals point outwards of the shape.
 """
 struct FittedCylinder{A<:AbstractArray, R<:Real} <: FittedShape
-    iscylinder::Bool
     axis::A
     center::A
     radius::R
@@ -17,26 +16,22 @@ struct FittedCylinder{A<:AbstractArray, R<:Real} <: FittedShape
 end
 
 Base.show(io::IO, x::FittedCylinder) =
-    print(io, """$(x.iscylinder ? "o" : "x") cylinder, R: $(x.radius)""")
+    print(io, """cylinder, R: $(x.radius)""")
 
 Base.show(io::IO, ::MIME"text/plain", x::FittedCylinder{A, R}) where {A, R} =
-    print(io, """FittedCylinder{$A, $R}\n$(x.iscylinder ? "o" : "x") cylinder, center: $(x.center), axis: $(x.axis), R: $(x.radius), $(x.outwards ? "outwards" : "inwards" )""")
+    print(io, """FittedCylinder{$A, $R}\ncylinder, center: $(x.center), axis: $(x.axis), R: $(x.radius), $(x.outwards ? "outwards" : "inwards" )""")
 
-strt(x::FittedCylinder) = "Cylinder"
-
-function isshape(shape::FittedCylinder)
-    return shape.iscylinder
-end
+strt(x::FittedCylinder) = "cylinder"
 
 function setcylinderOuterity(fc, b)
-    FittedCylinder(fc.iscylinder, fc.axis, fc.center, fc.radius, b)
+    FittedCylinder(fc.axis, fc.center, fc.radius, b)
 end
 
 function fit2pointcylinder(p, n, params)
     @unpack α_cylinder, ϵ_cylinder, parallelthrdeg = params
     # the normals are too parallel so cannot fit cylinder to it
     if abs(dot(n[1], n[2])) > cosd(parallelthrdeg)
-        return FittedCylinder(false, NaNVec, NaNVec, 0, false)
+        return nothing
     end
 
     an = normalize(n[1] × n[2])
@@ -119,7 +114,7 @@ function fit2pointcylinder(p, n, params)
 
     outw = dot(p12proj-p11proj, p11proj-interc) > 0
 
-    return FittedCylinder(true, an, c, R, outw)
+    return FittedCylinder(an, c, R, outw)
 end
 
 """
@@ -127,10 +122,7 @@ end
 
 Fit a cylinder to 2 points. Additional points and their normals are used to validate the fit.
 Normals are expected to be normalized.
-
-# Arguments:
-- `epsilon::Real`: maximum distance-difference between the fitted and measured spheres.
-- `alpharad::Real`: maximum difference between the normals (in radians).
+Return `nothing` if points do not fit to a cylinder.
 """
 function fitcylinder(p, n, params)
     @unpack ϵ_cylinder, α_cylinder, parallelthrdeg = params
@@ -141,7 +133,7 @@ function fitcylinder(p, n, params)
     # "forcefit" a cylinder
     fc = fit2pointcylinder(p, n, params)
 
-    fc.iscylinder || return fc
+    fc === nothing && return nothing
 
 
     thr = cos(α_cylinder)
@@ -158,10 +150,10 @@ function fitcylinder(p, n, params)
         norm_ok[i] = dotp > thr
         invnorm_ok[i] = dotp < -thr
     end
-    vert_ok == trues(pl) || return FittedCylinder(false, NaNVec, NaNVec, 0, false)
+    vert_ok == trues(pl) || return nothing
     norm_ok == trues(pl) && return setcylinderOuterity(fc, true)
     invnorm_ok == trues(pl) && return setcylinderOuterity(fc, false)
-    return FittedCylinder(false, NaNVec, NaNVec, 0, false)
+    return nothing
 end
 
 # bitmapping

--- a/src/shapes/plane.jl
+++ b/src/shapes/plane.jl
@@ -14,7 +14,7 @@ Base.show(io::IO, x::FittedPlane) =
     print(io, """plane""")
 
 Base.show(io::IO, ::MIME"text/plain", x::FittedPlane{A}) where {A} =
-    print(io, """FittedPlane{$A}\nplane, normal: $(x.normal), point: $(x.point) """)
+    print(io, """FittedPlane{$A}\nnormal: $(x.normal), point: $(x.point) """)
 
 strt(x::FittedPlane) = "plane"
 

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -16,7 +16,7 @@ Base.show(io::IO, x::FittedSphere) =
     print(io, """sphere, R: $(x.radius)""")
 
 Base.show(io::IO, ::MIME"text/plain", x::FittedSphere{A, R}) where {A, R} =
-    print(io, "FittedSphere{$A, $R}\n", """sphere, center: $(x.center), R: $(x.radius), $(x.outwards ? "outwards" : "inwards" )""")
+    print(io, "FittedSphere{$A, $R}\n", """center: $(x.center), R: $(x.radius), $(x.outwards ? "outwards" : "inwards" )""")
 
 strt(x::FittedSphere) = "sphere"
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -3,6 +3,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RegionTrees = "dee08c22-ab7f-5625-9660-a9af2021b33f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
 RegionTrees = "^0.3"

--- a/test/cone.jl
+++ b/test/cone.jl
@@ -25,6 +25,6 @@
     hcone = RANSAC.fitcone(cps[rrr], cns[rrr], p)
     hcone2 = RANSAC.fitcone(cps[rrr2], cns[rrr2], p)
 
-    @test hcone.iscone
-    @test hcone2.iscone
+    @test hcone isa FittedCone
+    @test hcone2 isa FittedCone
 end

--- a/test/dummyspheretest.jl
+++ b/test/dummyspheretest.jl
@@ -14,8 +14,8 @@ const defrp = RANSACParameters(rp, ϵ_sphere = EPSI, α_sphere = ALFI)
     tn1 = [SVector(0,-1,0.0), SVector(0,0,-1.0), SVector(1,0,0.0), SVector(0,1,0.0)]
     fs = fitsphere(tv1, tn1, defrp)
     fp = fitplane(tv1, tn1, RANSACParameters(defrp, α_plane=π/2, collin_threshold=0.2))
-    @test fs.issphere == true
-    @test fp.isplane == false
+    @test fs isa FittedSphere
+    @test fp === nothing
 end
 
 @testset "true sphere 2" begin
@@ -24,9 +24,9 @@ end
     fs1 = fitsphere(tv1, tn1, defrp) # true
     fs2 = fitsphere(tv1, tn1, RANSACParameters(defrp, ϵ_sphere=0.01)) # false, cause ϵ
     fp = fitplane(tv1, tn1, RANSACParameters(defrp, α_plane=π/2, collin_threshold=0.2))
-    @test fs1.issphere == true
-    @test fs2.issphere == false
-    @test fp.isplane == false
+    @test fs1 isa FittedSphere
+    @test fs2 === nothing
+    @test fp === nothing
 end
 
 @testset "false sphere 1" begin
@@ -36,7 +36,7 @@ end
     # should be false even with large thresholds
     fs2 = fitsphere(tv1, tn1, RANSACParameters(defrp, ϵ_sphere=10, α_sphere=π/2))
     fp = fitplane(tv1, tn1, RANSACParameters(defrp, α_plane=π/2, collin_threshold=0.2))
-    @test fs1.issphere == false
-    @test fs2.issphere == false
-    @test fp.isplane == false
+    @test fs1 === nothing
+    @test fs2 === nothing
+    @test fp === nothing
 end

--- a/test/json.jl
+++ b/test/json.jl
@@ -70,14 +70,14 @@
     io1 = IOBuffer()
     exportJSON(io1, s_cone, 2)
     string_io1 = String(take!(io1))
-    @test string_io1 == "{\n  \"opang\": 0.785,\n  \"outwards\": true,\n  \"axis\": [\n    -0.20180183819889375,\n    0.9417419115948374,\n    0.269069117598525\n  ],\n  \"apex\": [\n    0.0,\n    0.0,\n    0.0\n  ],\n  \"type\": \"cone\"\n}\n"
+    #@test string_io1 == "{\n  \"opang\": 0.785,\n  \"outwards\": true,\n  \"axis\": [\n    -0.20180183819889375,\n    0.9417419115948374,\n    0.269069117598525\n  ],\n  \"apex\": [\n    0.0,\n    0.0,\n    0.0\n  ],\n  \"type\": \"cone\"\n}\n"
     pd1 = JSON.parse(string_io1)
     @test pd1 == d_cone
 
     io2 = IOBuffer()
     exportJSON(io2, [s_plane, s_cone], 1)
     string_io2 = String(take!(io2))
-    @test string_io2 == "{\n \"primitives\": [\n  {\n   \"point\": [\n    15.6,\n    0.0,\n    -13.7\n   ],\n   \"normal\": [\n    0.5982430416161189,\n    0.7917922609625102,\n    0.1231676850386127\n   ],\n   \"type\": \"plane\"\n  },\n  {\n   \"opang\": 0.785,\n   \"outwards\": true,\n   \"axis\": [\n    -0.20180183819889375,\n    0.9417419115948374,\n    0.269069117598525\n   ],\n   \"apex\": [\n    0.0,\n    0.0,\n    0.0\n   ],\n   \"type\": \"cone\"\n  }\n ]\n}\n"
+    #@test string_io2 == "{\n \"primitives\": [\n  {\n   \"point\": [\n    15.6,\n    0.0,\n    -13.7\n   ],\n   \"normal\": [\n    0.5982430416161189,\n    0.7917922609625102,\n    0.1231676850386127\n   ],\n   \"type\": \"plane\"\n  },\n  {\n   \"opang\": 0.785,\n   \"outwards\": true,\n   \"axis\": [\n    -0.20180183819889375,\n    0.9417419115948374,\n    0.269069117598525\n   ],\n   \"apex\": [\n    0.0,\n    0.0,\n    0.0\n   ],\n   \"type\": \"cone\"\n  }\n ]\n}\n"
     pd2 = JSON.parse(string_io2)
     @test pd2 == Dict("primitives"=>[d_plane, d_cone])
 
@@ -85,14 +85,14 @@
     io3 = IOBuffer()
     exportJSON(io3, s_cylinder)
     string_io3 = String(take!(io3))
-    @test string_io3 == "{\"outwards\":false,\"axis\":[-17.1,8.0,2.42],\"radius\":0.13,\"center\":[15.6,0.0,-13.7],\"type\":\"cylinder\"}"
+    #@test string_io3 == "{\"outwards\":false,\"axis\":[-17.1,8.0,2.42],\"radius\":0.13,\"center\":[15.6,0.0,-13.7],\"type\":\"cylinder\"}"
     pd3 = JSON.parse(string_io3)
     @test pd3 == d_cylinder
 
     io4 = IOBuffer()
     exportJSON(io4, [s_plane, s_sphere, s_cone, s_plane])
     string_io4 = String(take!(io4))
-    @test string_io4 == "{\"primitives\":[{\"point\":[15.6,0.0,-13.7],\"normal\":[0.5982430416161189,0.7917922609625102,0.1231676850386127],\"type\":\"plane\"},{\"outwards\":true,\"radius\":13.23444,\"center\":[15.6,0.0,-13.7],\"type\":\"sphere\"},{\"opang\":0.785,\"outwards\":true,\"axis\":[-0.20180183819889375,0.9417419115948374,0.269069117598525],\"apex\":[0.0,0.0,0.0],\"type\":\"cone\"},{\"point\":[15.6,0.0,-13.7],\"normal\":[0.5982430416161189,0.7917922609625102,0.1231676850386127],\"type\":\"plane\"}]}"
+    #@test string_io4 == "{\"primitives\":[{\"point\":[15.6,0.0,-13.7],\"normal\":[0.5982430416161189,0.7917922609625102,0.1231676850386127],\"type\":\"plane\"},{\"outwards\":true,\"radius\":13.23444,\"center\":[15.6,0.0,-13.7],\"type\":\"sphere\"},{\"opang\":0.785,\"outwards\":true,\"axis\":[-0.20180183819889375,0.9417419115948374,0.269069117598525],\"apex\":[0.0,0.0,0.0],\"type\":\"cone\"},{\"point\":[15.6,0.0,-13.7],\"normal\":[0.5982430416161189,0.7917922609625102,0.1231676850386127],\"type\":\"plane\"}]}"
     pd4 = JSON.parse(string_io4)
     @test pd4 == Dict("primitives"=>[d_plane, d_sphere, d_cone, d_plane])
 

--- a/test/json.jl
+++ b/test/json.jl
@@ -1,0 +1,119 @@
+# testing json export by
+# exporting, then importing
+@testset "all in one" begin
+    # toDict
+
+    ## FottedShape
+    
+    # plane
+    p1 = SVector(15.6, 0, -13.7)
+    n1 = normalize(SVector(34,45,7))
+    s_plane = FittedPlane(p1, n1)
+    d_plane = RANSAC.toDict(s_plane)
+    
+    @test d_plane == Dict("type"=>"plane", "point"=>p1, "normal"=>n1)
+
+    # sphere
+    s_sphere = FittedSphere(p1, 13.23444, true)
+    d_sphere = RANSAC.toDict(s_sphere)
+
+    @test d_sphere == Dict("type"=>"sphere", "radius"=>13.23444, "center"=>p1, "outwards"=>true)
+
+    # cylinder
+    a1 = SVector(-17.1, 8, 2.42)
+    s_cylinder = FittedCylinder(a1, p1, 0.13, false)
+    d_cylinder = RANSAC.toDict(s_cylinder)
+
+    @test d_cylinder == Dict("type"=>"cylinder", "axis"=>a1, "center"=>p1, "radius"=>0.13, "outwards"=>false)
+
+    # cone
+    ap1 = SVector(0.0,0,0)
+    ax1 = normalize(SVector(-1.5, 7, 2))
+    s_cone = FittedCone(ap1, ax1, 0.785, true)
+    d_cone = RANSAC.toDict(s_cone)
+
+    @test d_cone == Dict("type"=>"cone", "apex"=>ap1, "axis"=>ax1, "opang"=>0.785, "outwards"=>true)
+
+    ## ShapeCandidate
+    sc1 = ShapeCandidate(s_plane, 5)
+    @test RANSAC.toDict(sc1) == d_plane
+
+    ## ScoredShape
+    ss1 = ScoredShape(ShapeCandidate(s_cone, 0), ConfidenceInterval(0,1.0), [1,2,3])
+    @test RANSAC.toDict(ss1) == d_cone
+
+    ## Array of primitives
+    sa = [s_plane, s_sphere, s_cylinder, s_cone]
+    sa_dict = [d_plane, d_sphere, d_cylinder, d_cone]
+    
+    d_sa = RANSAC.toDict(sa)
+
+    @test d_sa == Dict("primitives"=>sa_dict)
+
+    ## Array of ShapeCandidate
+    sc_a = [sc1]
+    sc_a_dict = [d_plane]
+
+    @test RANSAC.toDict(sc_a) == Dict("primitives"=>sc_a_dict)
+
+    ## Array of ScoredShape
+    ss2 = ScoredShape(ShapeCandidate(s_cylinder, 0), ConfidenceInterval(0.123,0.5), [1,2,3, 4])
+    ss_a = [ss1, ss2]
+    ss_a_dict = [d_cone, d_cylinder]
+
+    @test RANSAC.toDict(ss_a) == Dict("primitives"=>ss_a_dict)
+
+
+    # exportJSON
+
+    ## with indentation
+    io1 = IOBuffer()
+    exportJSON(io1, s_cone, 2)
+    string_io1 = String(take!(io1))
+    @test string_io1 == "{\n  \"opang\": 0.785,\n  \"outwards\": true,\n  \"axis\": [\n    -0.20180183819889375,\n    0.9417419115948374,\n    0.269069117598525\n  ],\n  \"apex\": [\n    0.0,\n    0.0,\n    0.0\n  ],\n  \"type\": \"cone\"\n}\n"
+    pd1 = JSON.parse(string_io1)
+    @test pd1 == d_cone
+
+    io2 = IOBuffer()
+    exportJSON(io2, [s_plane, s_cone], 1)
+    string_io2 = String(take!(io2))
+    @test string_io2 == "{\n \"primitives\": [\n  {\n   \"point\": [\n    15.6,\n    0.0,\n    -13.7\n   ],\n   \"normal\": [\n    0.5982430416161189,\n    0.7917922609625102,\n    0.1231676850386127\n   ],\n   \"type\": \"plane\"\n  },\n  {\n   \"opang\": 0.785,\n   \"outwards\": true,\n   \"axis\": [\n    -0.20180183819889375,\n    0.9417419115948374,\n    0.269069117598525\n   ],\n   \"apex\": [\n    0.0,\n    0.0,\n    0.0\n   ],\n   \"type\": \"cone\"\n  }\n ]\n}\n"
+    pd2 = JSON.parse(string_io2)
+    @test pd2 == Dict("primitives"=>[d_plane, d_cone])
+
+    ## Without indentation
+    io3 = IOBuffer()
+    exportJSON(io3, s_cylinder)
+    string_io3 = String(take!(io3))
+    @test string_io3 == "{\"outwards\":false,\"axis\":[-17.1,8.0,2.42],\"radius\":0.13,\"center\":[15.6,0.0,-13.7],\"type\":\"cylinder\"}"
+    pd3 = JSON.parse(string_io3)
+    @test pd3 == d_cylinder
+
+    io4 = IOBuffer()
+    exportJSON(io4, [s_plane, s_sphere, s_cone, s_plane])
+    string_io4 = String(take!(io4))
+    @test string_io4 == "{\"primitives\":[{\"point\":[15.6,0.0,-13.7],\"normal\":[0.5982430416161189,0.7917922609625102,0.1231676850386127],\"type\":\"plane\"},{\"outwards\":true,\"radius\":13.23444,\"center\":[15.6,0.0,-13.7],\"type\":\"sphere\"},{\"opang\":0.785,\"outwards\":true,\"axis\":[-0.20180183819889375,0.9417419115948374,0.269069117598525],\"apex\":[0.0,0.0,0.0],\"type\":\"cone\"},{\"point\":[15.6,0.0,-13.7],\"normal\":[0.5982430416161189,0.7917922609625102,0.1231676850386127],\"type\":\"plane\"}]}"
+    pd4 = JSON.parse(string_io4)
+    @test pd4 == Dict("primitives"=>[d_plane, d_sphere, d_cone, d_plane])
+
+    ## Write to file w&wo indentation
+    f1, fio1 = mktemp(pwd())
+    close(fio1)
+    open(f1, "w") do io
+        exportJSON(io, [s_plane, s_sphere, s_cone, s_plane], 4)
+    end
+    str_f1 = read(f1, String)
+    pd_f1 = JSON.parse(str_f1)
+    @test pd_f1 == Dict("primitives"=>[d_plane, d_sphere, d_cone, d_plane])
+    Base.Filesystem.rm(f1)
+
+    f2, fio2 = mktemp(pwd())
+    close(fio2)
+    open(f2, "w") do io
+        exportJSON(io, [s_plane, s_sphere, s_cone, s_plane, s_cylinder])
+    end
+    str_f2 = read(f2, String)
+    pd_f2 = JSON.parse(str_f2)
+    @test pd_f2 == Dict("primitives"=>[d_plane, d_sphere, d_cone, d_plane, d_cylinder])
+    Base.Filesystem.rm(f2)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using RANSAC
 using Test
 using LinearAlgebra
 using StaticArrays: SVector
+import JSON
 
 @testset "iswithinrectangle test" begin
     include("rectangletest.jl")
@@ -17,6 +18,10 @@ end
 
 @testset "cone" begin
     include("cone.jl")
+end
+
+@testset "json export" begin
+    include("json.jl")
 end
 
 #=


### PR DESCRIPTION
This PR implements basic JSON exporting based on [JSON.jl](https://github.com/JuliaIO/JSON.jl).
Should be easy to add importing as well, but that would need a constructor for `AbstractShape`s that takes `Dict` as argument.
Add tests too, though I'm not sure, that the order of the dictionaries will be always the same, therefore it's possible that those, which print to string will fail "randomly".