### PR TITLE
Optimizations

### DIFF
--- a/src/RANSAC.jl
+++ b/src/RANSAC.jl
@@ -4,7 +4,7 @@ using LinearAlgebra
 using Random
 using Logging
 using Logging: default_logcolor
-using StaticArrays: SVector, SMatrix
+using StaticArrays: SVector, SMatrix, MMatrix, StaticArray
 using RegionTrees
 #using Images: label_components, component_lengths, component_subscripts
 using ExtractMacro

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -132,7 +132,7 @@ function largestshape(A)
     return (index = bestind, size = bestscore)
 end
 
-function forcefitshapes!(pc, points, normals, parameters, candidates, level_array, octree_lev)
+function forcefitshapes!(points, normals, parameters, candidates, level_array, octree_lev)
     @extract parameters.iteration : shape_types
     for s in shape_types
         fitted = fit(s, points, normals, parameters)

--- a/src/iterations.jl
+++ b/src/iterations.jl
@@ -164,7 +164,7 @@ function ransac(pc, params; reset_rand = false)
             f_v = @view pc.vertices[sd]
             f_n = @view pc.normals[sd]
 
-            forcefitshapes!(pc, f_v, f_n, params, candidates, shape_octree_level, curr_level_i)
+            forcefitshapes!(f_v, f_n, params, candidates, shape_octree_level, curr_level_i)
         end # for t
 
         # evaluate the compatible points, currently used as score

--- a/src/shapes/cone.jl
+++ b/src/shapes/cone.jl
@@ -36,10 +36,8 @@ end
 
 ## fitting
 
-function fit3pointcone(psok, nsok)
+function fit3pointcone(p, n)
     # rank of the coefficient matrix
-    p = @view psok[1:3]
-    n = @view nsok[1:3]
     r = Array{Float64,2}(undef, (3,3))
     for i in 1:3; for j in 1:3; r[i,j] = n[i][j]; end; end
     rank(r) == 3 || return nothing
@@ -50,7 +48,7 @@ function fit3pointcone(psok, nsok)
     # apex
     ap = SVector{3, Float64}(r\ds)
     # axis
-    axis3p = [ap+((v-ap)/norm(v-ap)) for v in p]
+    axis3p = [ap+((p[i]-ap)/norm(p[i]-ap)) for i in 1:3]
     ax = normalize(cross(axis3p[2]-axis3p[1], axis3p[3]-axis3p[1]))
     midp = sum(axis3p)/3
     dirv = normalize(midp-ap)

--- a/src/shapes/cone.jl
+++ b/src/shapes/cone.jl
@@ -134,14 +134,21 @@ function compatiblesCone(cone, points, normals, params)
     #@unpack α_cone, ϵ_cone = params
     @extract params : params_cone=cone
     @extract params_cone : α_cone=α ϵ_cone=ϵ
-    calcs = [project2cone(cone, points[i]) for i in eachindex(points)]
+    calcs = (project2cone(cone, points[i]) for i in eachindex(points))
 
     # eps check
-    c1 = [abs(calcs[i][1]) < ϵ_cone for i in eachindex(calcs)]
+    # c1 = [abs(calcs[i][1]) < ϵ_cone for i in eachindex(calcs)]
+    #if cone.outwards
+    #    c2=[isparallel(calcs[i][2], normals[i], α_cone) && c1[i] for i in eachindex(calcs)]
+    #else
+    #    c2=[isparallel(-calcs[i][2], normals[i], α_cone) && c1[i] for i in eachindex(calcs)]
+    #end
+
+    zcn = zip(calcs, normals)
     if cone.outwards
-        c2=[isparallel(calcs[i][2], normals[i], α_cone) && c1[i] for i in eachindex(calcs)]
+        c2=[isparallel(c[2], n, α_cone) && (abs(c[1]) < ϵ_cone) for (c,n) in zcn]
     else
-        c2=[isparallel(-calcs[i][2], normals[i], α_cone) && c1[i] for i in eachindex(calcs)]
+        c2=[isparallel(-c[2], n, α_cone) && (abs(c[1]) < ϵ_cone) for (c,n) in zcn]
     end
     return c2
 end

--- a/src/shapes/cylinder.jl
+++ b/src/shapes/cylinder.jl
@@ -227,7 +227,9 @@ Refit cylinder. Only s.inpoints is updated.
 """
 function refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedCylinder}
     # TODO: use octree for that
-    cp = compatiblesCylinder(s.shape, pc.vertices[pc.isenabled], pc.normals[pc.isenabled], params)
+    pcv = @view pc.vertices[pc.isenabled]
+    pcn = @view pc.normals[pc.isenabled]
+    cp = compatiblesCylinder(s.shape, pcv, pcn, params)
     empty!(s.inpoints)
     append!(s.inpoints, ((1:pc.size)[pc.isenabled])[cp])
     return nothing

--- a/src/shapes/plane.jl
+++ b/src/shapes/plane.jl
@@ -111,7 +111,7 @@ function project2plane(plane, points)
     #    answer[i] = eltype(answer)(dot(o_x,v), dot(o_y,v), dot(o_z,v))
     #end
     #answer
-    return [proj_plane(ps) for ps in points]
+    return (proj_plane(ps) for ps in points)
 end
 
 """

--- a/src/shapes/plane.jl
+++ b/src/shapes/plane.jl
@@ -40,19 +40,7 @@ function fit(::Type{FittedPlane}, p, n, params)
     @assert lp == length(n) "Size must be the same."
     crossv = normalize(cross(p[2]-p[1], p[3]-p[1]))
     # how many point's normal must be checked
-    if norm(crossv) < collin_threshold
-        # The points are collinear
-        # solution: use 1 more point
-        if length(p) < 4
-            # return with false, cause no more points can be used
-            return nothing
-        end
-        crossv = normalize(cross(p[2]-p[4], p[3]-p[1]))
-        if norm(crossv) < collin_threshold
-            # return false, cause these are definitely on one line
-            return nothing
-        end
-    end
+    norm(crossv) < collin_threshold && return nothing
     # here we have the normal of the theoretical plane
     norm_ok = falses(lp)
     invnorm_ok = falses(lp)
@@ -148,7 +136,9 @@ Refit plane. Only s.inpoints is updated.
 """
 function refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedPlane}
     # TODO: use octree for that
-    cp = compatiblesPlane(s.shape, pc.vertices[pc.isenabled], pc.normals[pc.isenabled], params)
+    pcv = @view pc.vertices[pc.isenabled]
+    pcn = @view pc.normals[pc.isenabled]
+    cp = compatiblesPlane(s.shape, pcv, pcn, params)
     empty!(s.inpoints)
     append!(s.inpoints, ((1:pc.size)[pc.isenabled])[cp])
     return nothing

--- a/src/shapes/plane.jl
+++ b/src/shapes/plane.jl
@@ -130,11 +130,15 @@ function compatiblesPlane(plane, points, normals, params)
     @assert length(points) == length(normals) "Size must be the same."
     projecteds = project2plane(plane, points)
     # eps check
-    c1 = [abs(a[3]) < ϵ_plane for a in projecteds]
+    #c1 = [abs(a[3]) < ϵ_plane for a in projecteds]
     # alpha check
-    c2 = [isparallel(plane.normal, normals[i], α_plane) && c1[i] for i in eachindex(normals)]
-    # projecteds[c2] are the compatible points
-    return c2
+    #c2 = [isparallel(plane.normal, normals[i], α_plane) && c1[i] for i in eachindex(normals)]
+    # projecteds[comp] are the compatible points
+
+    # zip projected points and normals
+    zpn = zip(projecteds, normals) 
+    comp = [isparallel(plane.normal, n, α_plane) && (abs(p[3]) < ϵ_plane) for (p,n) in zpn]
+    return comp
 end
 
 """

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -178,7 +178,9 @@ Refit sphere. Only s.inpoints is updated.
 """
 function refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedSphere}
     # TODO: use octree for that
-    cpl = compatiblesSphere(s.shape, pc.vertices[pc.isenabled], pc.normals[pc.isenabled], params)
+    pcv = @view pc.vertices[pc.isenabled]
+    pcn = @view pc.normals[pc.isenabled]
+    cpl = compatiblesSphere(s.shape, pcv, pcn, params)
     # verti: összes pont indexe, ami enabled és kompatibilis
     verti = (1:pc.size)[pc.isenabled]
     #underEn = uo.under .& cpl

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -144,17 +144,25 @@ and an `alpharad` angle to it's normal.
 function compatiblesSphere(sphere, points, normals, params)
     #@unpack ϵ_sphere, α_sphere = params
     @extract params : params_sphere=sphere
-    @extract params_sphere : α_sphere=α ϵ_sphere=ϵ
+    @extract params_sphere : α ϵ
     @assert length(points) == length(normals) "Size must be the same."
     # eps check
     o = sphere.center
     R = sphere.radius
-    c1 = [abs(norm(a-o)-R) < ϵ_sphere for a in points]
+    # c1 = [abs(norm(a-o)-R) < ϵ_sphere for a in points]
     # alpha check
+    #if sphere.outwards
+    #    c2=[isparallel(normalize(points[i]-o), normals[i], α_sphere) && c1[i] for i in eachindex(points)]
+    #else
+    #    c2=[isparallel(normalize(o-points[i]), normals[i], α_sphere) && c1[i] for i in eachindex(points)]
+    #end
+
+    zpn = zip(points, normals)
+
     if sphere.outwards
-        c2=[isparallel(normalize(points[i]-o), normals[i], α_sphere) && c1[i] for i in eachindex(points)]
+        c2=[isparallel(normalize(p-o), n, α) && (abs(norm(p-o)-R) < ϵ) for (p,n) in zpn]
     else
-        c2=[isparallel(normalize(o-points[i]), normals[i], α_sphere) && c1[i] for i in eachindex(points)]
+        c2=[isparallel(normalize(o-p), n, α) && (abs(norm(p-o)-R) < ϵ) for (p,n) in zpn]
     end
 
     # TODO

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -5,9 +5,41 @@ Create a rotation matrix from a normalized axis and an angle (in radian).
 """
 function rodrigues(nv, Θ)
     et = eltype(nv)
-    R = zeros(et,3,3)
-    R = nv*nv' + cos(Θ).*(Matrix{et}(I, 3,3) - nv*nv') + sin(Θ).*crossprodtensor(nv)
+    #R = nv*nv' + cos(Θ).*(Matrix{et}(I, 3,3) - nv*nv') + sin(Θ).*crossprodtensor(nv)
+    R = nv*nv' + cos(Θ).*(Matrix(I, 3,3) - nv*nv')
+    pluscrossprod!(R, sin(Θ), nv)
     return R
+end
+
+"""
+    rodrigues(nv, Θ)
+
+Create a rotation matrix from a normalized axis and an angle (in radian).
+"""
+function rodrigues(nv::SA, Θ) where {SA<:StaticArray}
+    #R = nv*nv' + cos(Θ).*(Matrix{et}(I, 3,3) - nv*nv') + sin(Θ).*crossprodtensor(nv)
+    R = MMatrix{3,3}(nv*nv' + cos(Θ).*(Matrix(I, 3,3) - nv*nv'))
+    pluscrossprod!(R, sin(Θ), nv)
+    return SMatrix{3,3}(R)
+end
+
+"""
+    pluscrossprod!(A, value, v)
+
+Add a crossproduct tensor to `A`.
+Equals to: `A+value .* crossprodtensor(v)`
+"""
+function pluscrossprod!(A, value, v)
+    A[1,2] -= value*v[3]
+    A[1,3] += value*v[2]
+    
+    A[2,1] += value*v[3]
+    A[2,3] -= value*v[1]
+
+    A[3,1] -= value*v[2]
+    A[3,2] += value*v[1]
+
+    return A
 end
 
 """

--- a/test/utilitytests.jl
+++ b/test/utilitytests.jl
@@ -112,3 +112,22 @@ end
     dpars = merge(dpars, cop)
     @test isntequal(rpn, dpars)
 end
+
+@testset "cross prod" begin
+    A = rand(3,3)
+    val = deg2rad(15)
+    vec = normalize(rand(3))
+
+    orival = A + sin(val) .* RANSAC.crossprodtensor(vec)
+    dA = deepcopy(A)
+    RANSAC.pluscrossprod!(dA, sin(val), vec)
+    @test orival == dA
+
+    orival2 = A + RANSAC.crossprodtensor(vec)
+    dA2 = deepcopy(A)
+    RANSAC.pluscrossprod!(dA2, 1, vec)
+    @test orival2 == dA2
+
+    newval3 = RANSAC.pluscrossprod!(deepcopy(A), 0, vec)
+    @test A == newval3
+end


### PR DESCRIPTION
Making a couple optimizations to reduce runtime and allocations/gc.

List of changes:
- 54f0807 new function for adding the cross product tensor, that don't constructs the matrix
- 259e75e in `project2plane()` don't collect, just iterate
- b6a18fe use `zip()` in `compatible...()`, which avoids unnecessary allocations
- 25d5067 `@view` where necessary and don't where not

<details>
<summary>Before PR, on master</summary>
<br>

```julia

julia> using RANSAC, RANSACBenchmark, BenchmarkTools
[ Info: Precompiling RANSAC [d6bc97e0-a563-11e9-1861-c573f65f3bc3]
[ Info: Precompiling RANSACBenchmark [37ac5fee-0dc1-428d-87ed-e8867d5d5384]

julia> bc2 = benchmarkcloud2();

julia> pc = PointCloud(bc2.vertices, bc2.normals, 4);

julia> p = ransacparameters(iteration=(τ=100, itermax=20_000, prob_det=0.99,));

julia> extr, _ = ransac(pc, p, true; reset_rand=true);

julia> extr
4-element Array{ShapeCandidate,1}:
 Cand: (sphere, R: 5.0), 2567 ps
 Cand: (cone, ω: 0.7853981633974495), 868 ps
 Cand: (cylinder, R: 1.7899999999999996), 629 ps
 Cand: (plane), 312 ps

julia> @benchmark ransac($pc, $p, true; reset_rand=true) seconds=60
BenchmarkTools.Trial:
  memory estimate:  680.32 MiB
  allocs estimate:  6664208
  --------------
  minimum time:     1.237 s (5.35% GC)
  median time:      1.367 s (5.32% GC)
  mean time:        1.417 s (6.90% GC)
  maximum time:     1.856 s (15.79% GC)
  --------------
  samples:          43
  evals/sample:     1

julia> versioninfo()
Julia Version 1.4.0
Commit b8e9a9ecc6 (2020-03-21 16:36 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: Intel(R) Core(TM) i5-3570 CPU @ 3.40GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-8.0.1 (ORCJIT, ivybridge)
```

</details>