### PR TITLE
Struct of arrays pattern

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -149,6 +149,12 @@ The `ransac()` function does the iteration.
 ransac
 ```
 
+The iteration returns an array of `ExtractedShape`:
+
+```@docs
+ExtractedShape
+```
+
 ## Exporting the results
 
 With the help of [JSON.jl](https://github.com/JuliaIO/JSON.jl), the resulted shapes can be easily saved to JSON files.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -255,5 +255,5 @@ Under the hood, the `toDict()` function does the job of converting the primitive
 
 ```@docs
 RANSAC.toDict(s::FittedShape)
-RANSAC.toDict(::Vector{T}) where {T<:Union{FittedShape,ShapeCandidate}}
+RANSAC.toDict(::Vector{T}) where {T<:Union{FittedShape,ExtractedShape}}
 ```

--- a/docs/src/newprimitive.md
+++ b/docs/src/newprimitive.md
@@ -24,7 +24,7 @@ RANSAC.defaultshapeparameters
 RANSAC.fit
 RANSAC.scorecandidate
 RANSAC.estimatescore
-RANSAC.refit!
+RANSAC.refit
 RANSAC.strt
 ```
 

--- a/src/RANSAC.jl
+++ b/src/RANSAC.jl
@@ -12,7 +12,7 @@ import JSON
 import YAML
 
 import RegionTrees: AbstractRefinery, needs_refinement, refine_data
-import Base: show
+import Base: show, length, deleteat!
 
 # debuuugggggg
 #using Infiltrator
@@ -44,11 +44,11 @@ export  FittedShape,
         FittedSphere,
         FittedCylinder,
         FittedCone,
-        ShapeCandidate,
+        ExtractedShape,
         ransacparameters
 
 export  project2plane,
-        refit!
+        refit
 
 export  ransac,
         rerunleftover!

--- a/src/confidenceintervals.jl
+++ b/src/confidenceintervals.jl
@@ -1,7 +1,8 @@
 struct ConfidenceInterval
     min::Float64
     max::Float64
-    ConfidenceInterval(x, y) = x > y ? error("out of order") : new(x, y)
+    E::Float64
+    ConfidenceInterval(x, y) = x > y ? error("out of order") : new(x, y, (x+y)/2)
 end
 
 Base.show(io::IO, x::ConfidenceInterval) =
@@ -39,7 +40,7 @@ end
 
 Expected value of a [ConfidenceInterval](@ref).
 """
-E(x::ConfidenceInterval) = (x.min+x.max)/2
+E(x::ConfidenceInterval) = x.E
 
 
 """

--- a/src/json-yaml.jl
+++ b/src/json-yaml.jl
@@ -15,16 +15,16 @@ function toDict(s::FittedShape)
     d
 end
 
-toDict(sc::ShapeCandidate) = toDict(sc.shape)
+toDict(sc::ExtractedShape) = toDict(sc.shape)
 
 """
-    toDict(a::Vector{T}) where {T<:Union{FittedShape,ShapeCandidate}}
+    toDict(a::Vector{T}) where {T<:Union{FittedShape,ExtractedShape}}
 
 Convert a vector of shapes to a `Dict{String,Any}`.
 The top key is a "primitive", whose value is the array of the shapes.
 See the documentation for examples.
 """
-function toDict(a::Vector{T}) where {T<:Union{FittedShape,ShapeCandidate}}
+function toDict(a::Vector{T}) where {T<:Union{FittedShape,ExtractedShape}}
     ad = toDict.(a)
     return Dict("primitives"=>ad)
 end
@@ -32,12 +32,12 @@ end
 """
     printJSON(io::IO, s, indent)
 
-Print a `FittedShape`, `ShapeCandidate` or a vector of them to `io` as a JSON string.
+Print a `FittedShape`, `ExtractedShape` or a vector of them to `io` as a JSON string.
 With `indent` given, it prints a representation with newlines and indents.
 
 # Arguments:
 - `io::IO`: must be specified, use `stdout` for interactive purposes.
-- `s`: a `FittedShape`, `ShapeCandidate` or a vector of one of them.
+- `s`: a `FittedShape`, `ExtractedShape` or a vector of one of them.
 - `indent::Int`: indentation level.
 """
 function exportJSON(io::IO, s, indent)
@@ -47,12 +47,12 @@ end
 """
     printJSON(io::IO, s)
 
-Print a `FittedShape`, `ShapeCandidate`
+Print a `FittedShape`, `ExtractedShape`
 or a vector of them to `io` as a compact JSON string.
 
 # Arguments:
 - `io::IO`: must be specified, use `stdout` for interactive purposes.
-- `s`: a `FittedShape`, `ShapeCandidate` or a vector of one of them.
+- `s`: a `FittedShape`, `ExtractedShape` or a vector of one of them.
 """
 function exportJSON(io::IO, s)
     JSON.print(io, toDict(s))

--- a/src/shapes/cone.jl
+++ b/src/shapes/cone.jl
@@ -162,22 +162,20 @@ function scorecandidate(pc, candidate::FittedCone, subsetID, params)
     inder = cp.&ens
     inpoints = (pc.subsets[subsetID])[inder]
     score = estimatescore(length(pc.subsets[subsetID]), pc.size, length(inpoints))
-    return ShapeCandidate(candidate, score, inpoints)
+    return (score, inpoints)
 end
 
 ## refit
 
 """
-    refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedCone}
+    refit(s::T, pc, params) where {T<:FittedCone}
 
-Refit cone. Only s.inpoints is updated.
+Refit cone.
 """
-function refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedCone}
+function refit(s::T, pc, params) where {T<:FittedCone}
     # TODO: use octree for that
     p = @view pc.vertices[pc.isenabled]
     n = @view pc.normals[pc.isenabled]
-    cp = compatiblesCone(s.shape, p, n, params)
-    empty!(s.inpoints)
-    append!(s.inpoints, ((1:pc.size)[pc.isenabled])[cp])
-    return nothing
+    cp = compatiblesCone(s, p, n, params)
+    return ExtractedShape(s, ((1:pc.size)[pc.isenabled])[cp])
 end

--- a/src/shapes/cylinder.jl
+++ b/src/shapes/cylinder.jl
@@ -179,7 +179,7 @@ function scorecandidate(pc, candidate::FittedCylinder, subsetID, params)
     inpoints = (pc.subsets[subsetID])[inder]
     #inpoints = ((pc.subsets[1])[ens])[cp]
     score = estimatescore(length(pc.subsets[subsetID]), pc.size, length(inpoints))
-    return ShapeCandidate(candidate, score, inpoints)
+    return (score, inpoints)
 end
 
 """
@@ -221,16 +221,14 @@ function compatiblesCylinder(cylinder, points, normals, params)
 end
 
 """
-    refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedCylinder}
+    refit(s::T, pc, params) where {T<:FittedCylinder}
 
-Refit cylinder. Only s.inpoints is updated.
+Refit cylinder.
 """
-function refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedCylinder}
+function refit(s::T, pc, params) where {T<:FittedCylinder}
     # TODO: use octree for that
     pcv = @view pc.vertices[pc.isenabled]
     pcn = @view pc.normals[pc.isenabled]
     cp = compatiblesCylinder(s.shape, pcv, pcn, params)
-    empty!(s.inpoints)
-    append!(s.inpoints, ((1:pc.size)[pc.isenabled])[cp])
-    return nothing
+    return ExtractedShape(s, ((1:pc.size)[pc.isenabled])[cp])
 end

--- a/src/shapes/plane.jl
+++ b/src/shapes/plane.jl
@@ -67,7 +67,7 @@ function scorecandidate(pc, candidate::FittedPlane, subsetID, params)
     inder = cp.&ens
     inpoints = (pc.subsets[subsetID])[inder]
     score = estimatescore(length(pc.subsets[subsetID]), pc.size, length(inpoints))
-    return ShapeCandidate(candidate, score, inpoints)
+    return (score, inpoints)
 end
 
 """
@@ -130,16 +130,14 @@ function compatiblesPlane(plane, points, normals, params)
 end
 
 """
-    refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedPlane}
+    refit(s::T, pc, params) where {T<:FittedPlane}
 
-Refit plane. Only s.inpoints is updated.
+Refit plane.
 """
-function refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedPlane}
+function refit(s::T, pc, params) where {T<:FittedPlane}
     # TODO: use octree for that
     pcv = @view pc.vertices[pc.isenabled]
     pcn = @view pc.normals[pc.isenabled]
     cp = compatiblesPlane(s.shape, pcv, pcn, params)
-    empty!(s.inpoints)
-    append!(s.inpoints, ((1:pc.size)[pc.isenabled])[cp])
-    return nothing
+    return ExtractedShape(s, ((1:pc.size)[pc.isenabled])[cp])
 end

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -130,7 +130,7 @@ function scorecandidate(pc, candidate::FittedSphere, subsetID, params)
     #inpoints = count(underEn) >= count(overEn) ? verti[underEn] : verti[overEn]
     inpoints = verti[cpl]
     score = estimatescore(length(pc.subsets[subsetID]), pc.size, length(inpoints))
-    return ShapeCandidate(candidate, score, inpoints)
+    return (score, inpoints)
 end
 
 """
@@ -172,11 +172,11 @@ function compatiblesSphere(sphere, points, normals, params)
 end
 
 """
-    refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedSphere}
+    refit(s::T, pc, params) where {T<:FittedSphere}
 
-Refit sphere. Only s.inpoints is updated.
+Refit sphere.
 """
-function refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedSphere}
+function refit(s::T, pc, params) where {T<:FittedSphere}
     # TODO: use octree for that
     pcv = @view pc.vertices[pc.isenabled]
     pcn = @view pc.normals[pc.isenabled]
@@ -186,7 +186,5 @@ function refit!(s::ShapeCandidate{T}, pc, params) where {T<:FittedSphere}
     #underEn = uo.under .& cpl
     #overEn = uo.over .& cpl
     #s.inpoints = count(underEn) >= count(overEn) ? verti[underEn] : verti[overEn]
-    empty!(s.inpoints)
-    append!(s.inpoints, verti[cpl])
-    return nothing
+    return ExtractedShape(s, verti[cpl])
 end

--- a/test/confidenceintervals.jl
+++ b/test/confidenceintervals.jl
@@ -1,0 +1,26 @@
+@testset "confident tests" begin
+    a = 1.0
+    b = 3
+    ci1 = ConfidenceInterval(a, b)
+    @test ci1.E == 2.0
+    @test ci1.min === 1.0
+    @test ci1.max === 3.0
+
+    @test_throws ErrorException ConfidenceInterval(b, a)
+end
+
+@testset "not so confident tests" begin
+    a = 9.7
+    b = 153.9
+
+    nc1 = notsoconfident(b, a)
+    nc2 = notsoconfident(a, b)
+    
+    @test nc1.min == 9.7
+    @test nc1.max == 153.9
+    @test nc1.E == 81.8
+        
+    @test nc1.min == nc2.min
+    @test nc1.max == nc2.max
+    @test nc1.E == nc2.E
+end

--- a/test/fitting.jl
+++ b/test/fitting.jl
@@ -1,0 +1,19 @@
+@testset "IterationCandidates" begin
+    ic = RANSAC.IterationCandidates()
+    fp = FittedPlane(SVector(0.5,0.5,0.5), SVector{3}(0,0,1.))
+    sc = ConfidenceInterval(0,1)
+    inds = [1,2,3,4,5]
+    
+    @test length(ic) == 0
+    RANSAC.recordscore!(ic, fp, sc, inds)
+    @test length(ic) == 1
+    @test size(ic.shapes,1) == 1
+    @test size(ic.scores,1) == 1
+    @test size(ic.inpoints,1) == 1
+
+    deleteat!(ic, 1)
+    @test length(ic) == 0
+    @test size(ic.shapes,1) == 0
+    @test size(ic.scores,1) == 0
+    @test size(ic.inpoints,1) == 0
+end

--- a/test/json.jl
+++ b/test/json.jl
@@ -34,11 +34,11 @@
 
     @test d_cone == Dict("type"=>"cone", "apex"=>ap1, "axis"=>ax1, "opang"=>0.785, "outwards"=>true)
 
-    ## ShapeCandidate
-    sc1 = ShapeCandidate(s_plane, ConfidenceInterval(0.5,0.9), [1])
+    ## ExtractedShape
+    sc1 = ExtractedShape(s_plane, [1])
     @test RANSAC.toDict(sc1) == d_plane
 
-    ss1 = ShapeCandidate(s_cone, ConfidenceInterval(0,1.0), [1,2,3])
+    ss1 = ExtractedShape(s_cone, [1,2,3])
     @test RANSAC.toDict(ss1) == d_cone
 
     ## Array of primitives
@@ -49,7 +49,7 @@
 
     @test d_sa == Dict("primitives"=>sa_dict)
 
-    ## Array of ShapeCandidate
+    ## Array of ExtractedShape
     sc_a = [sc1, ss1]
     sc_a_dict = [d_plane, d_cone]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,11 @@ end
     include("confidenceintervals.jl")
 end
 
+@testset "fitting tools" begin
+    include("fitting.jl")
+end
+
+
 #=
 @testset "parameterspace bitmap" begin
     include("parameterspacebitmap.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,10 @@ end
     include("yaml.jl")
 end
 
+@testset "confidence interval" begin
+    include("confidenceintervals.jl")
+end
+
 #=
 @testset "parameterspace bitmap" begin
     include("parameterspacebitmap.jl")


### PR DESCRIPTION
I hope that using soa pattern instead of array of `ScoredShape`s will achieve better performance.

Edit:
Before on master:
```julia

julia> using RANSAC, RANSACBenchmark, BenchmarkTools
[ Info: Precompiling RANSAC [d6bc97e0-a563-11e9-1861-c573f65f3bc3]
[ Info: Precompiling RANSACBenchmark [37ac5fee-0dc1-428d-87ed-e8867d5d5384]

julia> bc2 = benchmarkcloud2();

julia> pc = PointCloud(bc2.vertices, bc2.normals, 4);

julia> p = ransacparameters(iteration=(τ=100, itermax=20_000, prob_det=0.99,));

julia> extr, _ = ransac(pc, p, true; reset_rand=true);

julia> extr
4-element Array{ShapeCandidate,1}:
 Cand: (sphere, R: 5.0), 2567 ps
 Cand: (cone, ω: 0.7853981633974495), 868 ps
 Cand: (cylinder, R: 1.7899999999999996), 629 ps
 Cand: (plane), 312 ps

julia> @benchmark ransac($pc, $p, true; reset_rand=true) seconds=60
BenchmarkTools.Trial:
  memory estimate:  680.32 MiB
  allocs estimate:  6664208
  --------------
  minimum time:     1.196 s (4.96% GC)
  median time:      1.325 s (5.26% GC)
  mean time:        1.343 s (6.90% GC)
  maximum time:     1.700 s (16.02% GC)
  --------------
  samples:          45
  evals/sample:     1

julia> versioninfo()
Julia Version 1.4.0
Commit b8e9a9ecc6 (2020-03-21 16:36 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: Intel(R) Core(TM) i5-3570 CPU @ 3.40GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-8.0.1 (ORCJIT, ivybridge)
```