### PR TITLE
enable fitting array of shapes in fitting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@ In this file I keep track of the changes from release to release.
 
 - **BREAKING**: pass `RANSACCloud` too when fitting shapes - [docs](https://csertegt3.github.io/RANSAC.jl/stable/newprimitive/)
 
+### v0.5.1
+
+#### Changes
+
+- enable returning multiple shapes when fitting - [docs](https://csertegt3.github.io/RANSAC.jl/stable/newprimitive/)
+
 ## v0.4.0
 
 #### Changes

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -24,7 +24,8 @@ Return `nothing`, if can't fit the shape to the points.
 # Implementation
 Signature: `fit(::Type{MyShape}, p, n, pc, params)`.
 
-It should return an instance of `MyShape` or `nothing`.
+It should return `nothing` if the fit wasn't succesfull, `MyShape` otherwise.
+If the fit results multiple shapes, it can return an array of `MyShape`s as well.
 """
 function fit end
 
@@ -151,13 +152,17 @@ function findhighestscore(A::IterationCandidates)
     return (index = ind, overlap = false)
 end
 
+"""
+    forcefitshapes!(points, normals, parameters, candidates, level_array, octree_lev, pc)
+
+Call `fit` based on the given parameters and add valid candidates to
+"""
 function forcefitshapes!(points, normals, parameters, candidates, level_array, octree_lev, pc)
     @extract parameters.iteration : shape_types
     for s in shape_types
         fitted = fit(s, points, normals, pc, parameters)
         fitted === nothing && continue
-        push!(candidates, fitted)
-        push!(level_array, octree_lev)
+        push2candidatesandlevels!(candidates, fitted, level_array, octree_lev)
     end
     return nothing
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -462,3 +462,20 @@ function ransacparameters(p::Array{T}; kwargs...) where {T<:UnionAll}
     dpars = defaultparameters(p)
     return ransacparameters(dpars; kwargs...)
 end
+
+"""
+    push2candidatesandlevels!(candidates, candidate, levels, current_level)
+
+Push `candidate` to `candidates` and `current_level` to `levels`.
+Handle the case, when `candidate` is an array of candidates.
+Used in [`forcefitshapes!`](@ref).
+"""
+function push2candidatesandlevels!(candidates, candidate, levels, current_level)
+    push!(candidates, candidate)
+    push!(levels, current_level)
+end
+
+function push2candidatesandlevels!(candidates, candidate::AbstractArray, levels, current_level)
+    append!(candidates, candidate)
+    append!(levels, fill(current_level, size(candidate)))
+end

--- a/test/utilitytests.jl
+++ b/test/utilitytests.jl
@@ -131,3 +131,20 @@ end
     newval3 = RANSAC.pluscrossprod!(deepcopy(A), 0, vec)
     @test A == newval3
 end
+
+@testset "push2candidatesandlevels!" begin
+    fp = FittedPlane(SVector(0.5,0.5,0.5), SVector{3}(0,0,1.))
+    candidates = FittedShape[]
+    levels = Int[]
+
+    RANSAC.push2candidatesandlevels!(candidates, fp, levels, 3)
+    @test size(candidates) == (1,)
+    @test size(levels) == (1,)
+
+    RANSAC.push2candidatesandlevels!(candidates, [fp, fp], levels, 0)
+    @test size(candidates) == (3,)
+    @test size(levels) == (3,)
+    @test levels[1] == 3
+    @test levels[2] == 0
+    @test levels[3] == 0
+end


### PR DESCRIPTION
There are cases, when fitting would result in multiple fits, for example in my implementation of translational surfaces. This PR changes the function that handles the results of `fit()` to handle this case